### PR TITLE
update belgium regex to accept first digit 1

### DIFF
--- a/lib/vat_check/format.rb
+++ b/lib/vat_check/format.rb
@@ -10,7 +10,7 @@ class VatCheck
     def self.patterns
       @patterns ||= {
         'AT' => /\AATU[0-9]{8}\Z/,                                          # Austria
-        'BE' => /\ABE0[0-9]{9}\Z/,                                          # Belgium
+        'BE' => /\ABE[01][0-9]{9}\Z/,                                       # Belgium
         'BG' => /\ABG[0-9]{9,10}\Z/,                                        # Bulgaria
         'CY' => /\ACY[0-9]{8}[A-Z]\Z/,                                      # Cyprus
         'CZ' => /\ACZ[0-9]{8,10}\Z/,                                        # Czech Republic

--- a/spec/vat_check/format_spec.rb
+++ b/spec/vat_check/format_spec.rb
@@ -4,6 +4,7 @@ describe VatCheck::Format do
   valid_vat_ids = [
     'ATU99999999',        # AT-Austria
     'BE0999999999',       # BE-Belgium
+    'BE1999999999',       # BE-Belgium
     'BG999999999',        # BG-Bulgaria
     'BG9999999999',       # BG-Bulgaria
     'CY99999999L',        # CY-Cyprus


### PR DESCRIPTION
Minor PR to update the regex for belgium to accept BE1 as the prefix ([source](https://www.vatcalc.com/belgium/belgian-vat-number-format-changes/)).